### PR TITLE
Echo SRC and DST before deployment

### DIFF
--- a/ci/ci-generator.py
+++ b/ci/ci-generator.py
@@ -84,13 +84,13 @@ stages:
   - deploy_base_image"""
 )
 
-templates = [{"template_file": 'ci/templates/base_image.yml.j2',
+templates = [{"template_file": 'ci/templates/build_image.yml.j2',
               "os_dict": config["os"],
               "spackver_list": config["spackver"],
               "cudaver_list": config["cudaver"],
               "rocmver_list": config["rocmver"],
              },
-             {"template_file": 'ci/templates/helper_image.yml.j2',
+             {"template_file": 'ci/templates/runtime_image.yml.j2',
               "os_dict": config["os"],
               "spackver_list": [None],
               "cudaver_list": config["cudaver"],

--- a/ci/templates/build_image.yml.j2
+++ b/ci/templates/build_image.yml.j2
@@ -60,6 +60,7 @@ deploy_job_build_image-{{os}}{{osver}}-spack{{spackver}}-{{archstr[arch]}}-jfrog
     - DST=$DST_JFROG
     - DST_REGISTRY=${DST%%/*}
     - echo ${CSCS_REGISTRY_PASSWORD} | skopeo login --username ${CSCS_REGISTRY_USER} --password-stdin ${DST_REGISTRY}
+    - echo "Copying ${SRC} to ${DST}"
     - skopeo copy --multi-arch=all "docker://${SRC}" "docker://${DST}"
 
 deploy_job_build_image-{{os}}{{osver}}-spack{{spackver}}-{{archstr[arch]}}-github:
@@ -85,5 +86,6 @@ deploy_job_build_image-{{os}}{{osver}}-spack{{spackver}}-{{archstr[arch]}}-githu
     - SRC_REGISTRY=${SRC%%/*}
     - echo ${CSCS_REGISTRY_PASSWORD} | skopeo login --username ${CSCS_REGISTRY_USER} --password-stdin ${SRC_REGISTRY}
     - echo ${DEPLOY_GITHUB_PASSWORD} | skopeo login --username ${DEPLOY_GITHUB_USERNAME} --password-stdin ${DST_REGISTRY}
+    - echo "Copying ${SRC} to ${DST}"
     - skopeo copy --multi-arch=all "docker://${SRC}" "docker://${DST}"
 {% endif %}

--- a/ci/templates/runtime_image.yml.j2
+++ b/ci/templates/runtime_image.yml.j2
@@ -58,6 +58,7 @@ deploy_job_runtime_image-{{os}}{{osver}}-{{archstr[arch]}}-jfrog:
     - DST=$DST_JFROG
     - DST_REGISTRY=${DST%%/*}
     - echo ${CSCS_REGISTRY_PASSWORD} | skopeo login --username ${CSCS_REGISTRY_USER} --password-stdin ${DST_REGISTRY}
+    - echo "Copying ${SRC} to ${DST}"
     - skopeo copy --multi-arch=all "docker://${SRC}" "docker://${DST}"
 
 deploy_job_runtime_image-{{os}}{{osver}}-{{archstr[arch]}}-github:
@@ -83,5 +84,6 @@ deploy_job_runtime_image-{{os}}{{osver}}-{{archstr[arch]}}-github:
     - SRC_REGISTRY=${SRC%%/*}
     - echo ${CSCS_REGISTRY_PASSWORD} | skopeo login --username ${CSCS_REGISTRY_USER} --password-stdin ${SRC_REGISTRY}
     - echo ${DEPLOY_GITHUB_PASSWORD} | skopeo login --username ${DEPLOY_GITHUB_USERNAME} --password-stdin ${DST_REGISTRY}
+    - echo "Copying ${SRC} to ${DST}"
     - skopeo copy --multi-arch=all "docker://${SRC}" "docker://${DST}"
 {% endif %}


### PR DESCRIPTION
This allows much easier to see in the log output what has been deployed.
Also the template files are renamed to match the corresponding image names.